### PR TITLE
Valid e-mail address is required

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -28,9 +28,9 @@ class ContactDimagiForm(forms.Form):
         label=ugettext_noop("Company / Organization"),
         required=False,
     )
-    email = forms.CharField(
+    email = forms.EmailField(
         label=ugettext_noop("Email Address"),
-        required=False,
+        required=True,
     )
     phone_number = forms.CharField(
         label=ugettext_noop("Phone Number"),

--- a/static/prelogin/js/hq_public_contact.ng.js
+++ b/static/prelogin/js/hq_public_contact.ng.js
@@ -13,12 +13,18 @@
         var self = {};
 
         self.showSuccessMessage = function (resp) {
-            // hide modal
-            $('#contactDimagi').modal('hide');
-            // reset form
-            $('#contact-dimagi-form')[0].reset();
-            // show success modal
-            $('#thanksForContactingUs').modal('show');
+            // This gets called when we get a 200 <= status code < 300, even
+            // if there were form errors, so we need to check for them.
+            if (!resp.success) {
+                $('#contactUsFormErrors').modal('show');
+            } else {
+                // hide modal
+                $('#contactDimagi').modal('hide');
+                // reset form
+                $('#contact-dimagi-form')[0].reset();
+                // show success modal
+                $('#thanksForContactingUs').modal('show');
+            }
         };
 
         self.showErrorMessage = function () {

--- a/templates/prelogin/base.html
+++ b/templates/prelogin/base.html
@@ -205,6 +205,32 @@
                 </div>
             </div>
         </div>
+        <div id="contactUsFormErrors"
+             class="modal fade">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">{% trans 'Close' %}</span></button>
+                        <h3 class="modal-title">
+                            {% trans "Ooops!" %}
+                        </h3>
+                    </div>
+                    <div class="modal-body">
+                        <p>
+                            {% comment %}
+                                There is only one field that can result in errors,
+                                so it's safe to assume the problem is the e-mail
+                                address.
+                            {% endcomment %}
+                            {% blocktrans %}
+                                Please provide a valid e-mail address where we can reach you.
+                            {% endblocktrans %}
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+        </body>
         {% block modals %}{% endblock modals %}
 
         {# Javascript #}

--- a/views.py
+++ b/views.py
@@ -26,9 +26,9 @@ class BasePreloginView(JSONResponseMixin, TemplateView):
         contact_form = ContactDimagiForm(in_data)
         if contact_form.is_valid():
             contact_form.send_email()
-        return {
-            'success': True,
-        }
+            return {'success': True}
+        else:
+            return {'success': False, 'errors': contact_form.errors}
 
 
 class HomePublicView(BasePreloginView):


### PR DESCRIPTION
For [FB 167949](http://manage.dimagi.com/default.asp?167949)

Two considerations:
  1. The form will display "Email Address\*" (with an asterisk) but won't
     explain that the "\*" denotes a mandatory field. I don't think this is a
     big deal; most people are literate enough to know what that means without
     a footnote.
  2. This will fail silently. If the user omits their e-mail address, or fills
     in an invalid one, they won't get any feedback telling them that their
     e-mail was not sent. I think this is a problem. This commit is a quick
     fix, but the view ought to be extended to return an error message, and
     the modal form needs to be modified to display errors, and allow the user
     to try again.

So, code reviewers, do you reckon we merge this now to resolve the immediate bug, and open another ticket to improve the view later? Or do we spend a bit more time on this now? I'm easy.

@amsagoff, @millerdev 
