### PR TITLE
Security page pricing tweaks and pricing page cleanup

### DIFF
--- a/static/prelogin/less/components/pricing-section.less
+++ b/static/prelogin/less/components/pricing-section.less
@@ -21,7 +21,7 @@
 @pricing-fifth-section-height-xs: 191px;
 @pricing-fifth-section-height-sm: 176px;
 @pricing-fifth-section-height-md: 181px;
-@pricing-fifth-section-height-lg: 215px;
+@pricing-fifth-section-height-lg: 363px;
 
 @pricing-sixth-section-height-xs: 354px;
 @pricing-sixth-section-height-sm: 354px;

--- a/static/prelogin/less/components/pricing-section.less
+++ b/static/prelogin/less/components/pricing-section.less
@@ -16,7 +16,7 @@
 @pricing-fourth-section-height-xs: 486px;
 @pricing-fourth-section-height-sm: 486px;
 @pricing-fourth-section-height-md: 481px;
-@pricing-fourth-section-height-lg: 555px;
+@pricing-fourth-section-height-lg: 496px;
 
 @pricing-fifth-section-height-xs: 191px;
 @pricing-fifth-section-height-sm: 176px;

--- a/templates/prelogin/_sections/pricing/01_app_mangement.html
+++ b/templates/prelogin/_sections/pricing/01_app_mangement.html
@@ -18,33 +18,7 @@
                             </h2>
                         </div>
                     </div>
-                    <div class="row pricing-row pricing-row-plan-names">
-                        <div class="col-xs-2 pricing-col-community col-xs-offset-2">
-                            <h3 class="pricing-header text-uppercase">
-                                {% trans 'Community' %}
-                            </h3>
-                        </div>
-                        <div class="col-xs-2 pricing-col-standard">
-                            <h3 class="pricing-header text-uppercase">
-                                {% trans 'Standard' %}
-                            </h3>
-                        </div>
-                        <div class="col-xs-2 pricing-col-pro">
-                            <h3 class="pricing-header text-uppercase">
-                                {% trans 'Pro' %}
-                            </h3>
-                        </div>
-                        <div class="col-xs-2 pricing-col-advanced">
-                            <h3 class="pricing-header text-uppercase">
-                                {% trans 'Advanced' %}
-                            </h3>
-                        </div>
-                        <div class="col-xs-2 pricing-col-enterprise">
-                            <h3 class="pricing-header text-uppercase">
-                                {% trans 'Enterprise' %}
-                            </h3>
-                        </div>
-                    </div>
+                    {% include 'prelogin/_sections/pricing/partials/section_plan_headers.html' %}
                 </div>
             </div>
             <div class="container">

--- a/templates/prelogin/_sections/pricing/02_app_features.html
+++ b/templates/prelogin/_sections/pricing/02_app_features.html
@@ -18,33 +18,7 @@
                             </h2>
                         </div>
                     </div>
-                    <div class="row pricing-row pricing-row-plan-names">
-                        <div class="col-xs-2 pricing-col-community col-xs-offset-2">
-                            <h3 class="pricing-header text-uppercase">
-                                {% trans 'Community' %}
-                            </h3>
-                        </div>
-                        <div class="col-xs-2 pricing-col-standard">
-                            <h3 class="pricing-header text-uppercase">
-                                {% trans 'Standard' %}
-                            </h3>
-                        </div>
-                        <div class="col-xs-2 pricing-col-pro">
-                            <h3 class="pricing-header text-uppercase">
-                                {% trans 'Pro' %}
-                            </h3>
-                        </div>
-                        <div class="col-xs-2 pricing-col-advanced">
-                            <h3 class="pricing-header text-uppercase">
-                                {% trans 'Advanced' %}
-                            </h3>
-                        </div>
-                        <div class="col-xs-2 pricing-col-enterprise">
-                            <h3 class="pricing-header text-uppercase">
-                                {% trans 'Enterprise' %}
-                            </h3>
-                        </div>
-                    </div>
+                    {% include 'prelogin/_sections/pricing/partials/section_plan_headers.html' %}
                 </div>
             </div>
             <div class="container">

--- a/templates/prelogin/_sections/pricing/03_messaging_sms.html
+++ b/templates/prelogin/_sections/pricing/03_messaging_sms.html
@@ -25,33 +25,7 @@
                             </p>
                         </div>
                     </div>
-                    <div class="row pricing-row pricing-row-plan-names">
-                        <div class="col-xs-2 pricing-col-community col-xs-offset-2">
-                            <h3 class="pricing-header text-uppercase">
-                                {% trans 'Community' %}
-                            </h3>
-                        </div>
-                        <div class="col-xs-2 pricing-col-standard">
-                            <h3 class="pricing-header text-uppercase">
-                                {% trans 'Standard' %}
-                            </h3>
-                        </div>
-                        <div class="col-xs-2 pricing-col-pro">
-                            <h3 class="pricing-header text-uppercase">
-                                {% trans 'Pro' %}
-                            </h3>
-                        </div>
-                        <div class="col-xs-2 pricing-col-advanced">
-                            <h3 class="pricing-header text-uppercase">
-                                {% trans 'Advanced' %}
-                            </h3>
-                        </div>
-                        <div class="col-xs-2 pricing-col-enterprise">
-                            <h3 class="pricing-header text-uppercase">
-                                {% trans 'Enterprise' %}
-                            </h3>
-                        </div>
-                    </div>
+                    {% include 'prelogin/_sections/pricing/partials/section_plan_headers.html' %}
                 </div>
             </div>
             <div class="container">

--- a/templates/prelogin/_sections/pricing/04_reporting_analytics.html
+++ b/templates/prelogin/_sections/pricing/04_reporting_analytics.html
@@ -18,33 +18,7 @@
                             </h2>
                         </div>
                     </div>
-                    <div class="row pricing-row pricing-row-plan-names">
-                        <div class="col-xs-2 pricing-col-community col-xs-offset-2">
-                            <h3 class="pricing-header text-uppercase">
-                                {% trans 'Community' %}
-                            </h3>
-                        </div>
-                        <div class="col-xs-2 pricing-col-standard">
-                            <h3 class="pricing-header text-uppercase">
-                                {% trans 'Standard' %}
-                            </h3>
-                        </div>
-                        <div class="col-xs-2 pricing-col-pro">
-                            <h3 class="pricing-header text-uppercase">
-                                {% trans 'Pro' %}
-                            </h3>
-                        </div>
-                        <div class="col-xs-2 pricing-col-advanced">
-                            <h3 class="pricing-header text-uppercase">
-                                {% trans 'Advanced' %}
-                            </h3>
-                        </div>
-                        <div class="col-xs-2 pricing-col-enterprise">
-                            <h3 class="pricing-header text-uppercase">
-                                {% trans 'Enterprise' %}
-                            </h3>
-                        </div>
-                    </div>
+                    {% include 'prelogin/_sections/pricing/partials/section_plan_headers.html' %}
                 </div>
             </div>
             <div class="container">

--- a/templates/prelogin/_sections/pricing/05_data_security.html
+++ b/templates/prelogin/_sections/pricing/05_data_security.html
@@ -18,33 +18,7 @@
                             </h2>
                         </div>
                     </div>
-                    <div class="row pricing-row pricing-row-plan-names">
-                        <div class="col-xs-2 pricing-col-community col-xs-offset-2">
-                            <h3 class="pricing-header text-uppercase">
-                                {% trans 'Community' %}
-                            </h3>
-                        </div>
-                        <div class="col-xs-2 pricing-col-standard">
-                            <h3 class="pricing-header text-uppercase">
-                                {% trans 'Standard' %}
-                            </h3>
-                        </div>
-                        <div class="col-xs-2 pricing-col-pro">
-                            <h3 class="pricing-header text-uppercase">
-                                {% trans 'Pro' %}
-                            </h3>
-                        </div>
-                        <div class="col-xs-2 pricing-col-advanced">
-                            <h3 class="pricing-header text-uppercase">
-                                {% trans 'Advanced' %}
-                            </h3>
-                        </div>
-                        <div class="col-xs-2 pricing-col-enterprise">
-                            <h3 class="pricing-header text-uppercase">
-                                {% trans 'Enterprise' %}
-                            </h3>
-                        </div>
-                    </div>
+                    {% include 'prelogin/_sections/pricing/partials/section_plan_headers.html' %}
                 </div>
             </div>
             <div class="container">

--- a/templates/prelogin/_sections/pricing/05_data_security.html
+++ b/templates/prelogin/_sections/pricing/05_data_security.html
@@ -11,7 +11,7 @@
                     <div class="row pricing-row pricing-row-main-header">
                         <div class="col-xs-12">
                             <h2>
-                                {% trans 'Data Security' %}
+                                {% trans 'Security' %}
                                 <a href="https://wiki.commcarehq.org/display/commcarepublic/CommCare+Plan+Details">
                                     <i class="fa fa-info-circle"></i>
                                 </a>

--- a/templates/prelogin/_sections/pricing/05_data_security.html
+++ b/templates/prelogin/_sections/pricing/05_data_security.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load pricing_tags %}
 <section id="data-security"
          class="section
                 section-default
@@ -24,75 +25,13 @@
             <div class="container">
                 <div class="row pricing-row pricing-row-main pricing-row-single
                             pricing-row-double-xs">
-                    <div class="col-xs-2">
-                        <h4>
-                            {% blocktrans %}
-                                Deidentified data
-                            {% endblocktrans %}
-                        </h4>
-                    </div>
-                    {# * * * * * #}
-                    <div class="col-xs-2 pricing-col-community">
-                        <div class="pricing-info">
-                            <p><i class="fa fa-minus"></i></p>
-                        </div>
-                    </div>
-                    <div class="col-xs-2 pricing-col-standard">
-                        <div class="pricing-info">
-                            <p><i class="fa fa-minus"></i></p>
-                        </div>
-                    </div>
-                    <div class="col-xs-2 pricing-col-pro">
-                        <div class="pricing-info">
-                            <p><i class="fa fa-check"></i></p>
-                        </div>
-                    </div>
-                    <div class="col-xs-2 pricing-col-advanced">
-                        <div class="pricing-info">
-                            <p><i class="fa fa-check"></i></p>
-                        </div>
-                    </div>
-                    <div class="col-xs-2 pricing-col-enterprise">
-                        <div class="pricing-info">
-                            <p><i class="fa fa-check"></i></p>
-                        </div>
-                    </div>
+                    {% trans "Deidentified data" as feature_name %}
+                    {% pricing_row_contents feature_name "pro" %}
                 </div>
                 <div class="row pricing-row pricing-row-main pricing-row-double
                             pricing-row-triple-xs">
-                    <div class="col-xs-2">
-                        <h4>
-                            {% blocktrans %}
-                                HIPAA compliance assurance
-                            {% endblocktrans %}
-                        </h4>
-                    </div>
-                    {# x x x * * #}
-                    <div class="col-xs-2 pricing-col-community">
-                        <div class="pricing-info">
-                            <p><i class="fa fa-minus"></i></p>
-                        </div>
-                    </div>
-                    <div class="col-xs-2 pricing-col-standard">
-                        <div class="pricing-info">
-                            <p><i class="fa fa-minus"></i></p>
-                        </div>
-                    </div>
-                    <div class="col-xs-2 pricing-col-pro">
-                        <div class="pricing-info">
-                            <p><i class="fa fa-minus"></i></p>
-                        </div>
-                    </div>
-                    <div class="col-xs-2 pricing-col-advanced">
-                        <div class="pricing-info">
-                            <p><i class="fa fa-check"></i></p>
-                        </div>
-                    </div>
-                    <div class="col-xs-2 pricing-col-enterprise">
-                        <div class="pricing-info">
-                            <p><i class="fa fa-check"></i></p>
-                        </div>
-                    </div>
+                    {% trans "HIPAA compliance assurance" as feature_name %}
+                    {% pricing_row_contents feature_name "advanced" %}
                 </div>
             </div>
         </div>

--- a/templates/prelogin/_sections/pricing/05_data_security.html
+++ b/templates/prelogin/_sections/pricing/05_data_security.html
@@ -23,10 +23,20 @@
                 </div>
             </div>
             <div class="container">
+                <div class="row pricing-row pricing-row-main pricing-row-double
+                            pricing-row-triple-xs">
+                    {% trans "Two-factor Authentication" as feature_name %}
+                    {% pricing_row_contents feature_name "community" %}
+                </div>
                 <div class="row pricing-row pricing-row-main pricing-row-single
                             pricing-row-double-xs">
                     {% trans "Deidentified data" as feature_name %}
                     {% pricing_row_contents feature_name "pro" %}
+                </div>
+                <div class="row pricing-row pricing-row-main pricing-row-double
+                            pricing-row-triple-xs">
+                    {% trans "Security Policy Control and Enforcement" as feature_name %}
+                    {% pricing_row_contents feature_name "advanced" %}
                 </div>
                 <div class="row pricing-row pricing-row-main pricing-row-double
                             pricing-row-triple-xs">

--- a/templates/prelogin/_sections/pricing/06_user_management.html
+++ b/templates/prelogin/_sections/pricing/06_user_management.html
@@ -18,33 +18,7 @@
                             </h2>
                         </div>
                     </div>
-                    <div class="row pricing-row pricing-row-plan-names">
-                        <div class="col-xs-2 pricing-col-community col-xs-offset-2">
-                            <h3 class="pricing-header text-uppercase">
-                                {% trans 'Community' %}
-                            </h3>
-                        </div>
-                        <div class="col-xs-2 pricing-col-standard">
-                            <h3 class="pricing-header text-uppercase">
-                                {% trans 'Standard' %}
-                            </h3>
-                        </div>
-                        <div class="col-xs-2 pricing-col-pro">
-                            <h3 class="pricing-header text-uppercase">
-                                {% trans 'Pro' %}
-                            </h3>
-                        </div>
-                        <div class="col-xs-2 pricing-col-advanced">
-                            <h3 class="pricing-header text-uppercase">
-                                {% trans 'Advanced' %}
-                            </h3>
-                        </div>
-                        <div class="col-xs-2 pricing-col-enterprise">
-                            <h3 class="pricing-header text-uppercase">
-                                {% trans 'Enterprise' %}
-                            </h3>
-                        </div>
-                    </div>
+                    {% include 'prelogin/_sections/pricing/partials/section_plan_headers.html' %}
                 </div>
             </div>
             <div class="container">

--- a/templates/prelogin/_sections/pricing/07_system_integration.html
+++ b/templates/prelogin/_sections/pricing/07_system_integration.html
@@ -18,33 +18,7 @@
                             </h2>
                         </div>
                     </div>
-                    <div class="row pricing-row pricing-row-plan-names">
-                        <div class="col-xs-2 pricing-col-community col-xs-offset-2">
-                            <h3 class="pricing-header text-uppercase">
-                                {% trans 'Community' %}
-                            </h3>
-                        </div>
-                        <div class="col-xs-2 pricing-col-standard">
-                            <h3 class="pricing-header text-uppercase">
-                                {% trans 'Standard' %}
-                            </h3>
-                        </div>
-                        <div class="col-xs-2 pricing-col-pro">
-                            <h3 class="pricing-header text-uppercase">
-                                {% trans 'Pro' %}
-                            </h3>
-                        </div>
-                        <div class="col-xs-2 pricing-col-advanced">
-                            <h3 class="pricing-header text-uppercase">
-                                {% trans 'Advanced' %}
-                            </h3>
-                        </div>
-                        <div class="col-xs-2 pricing-col-enterprise">
-                            <h3 class="pricing-header text-uppercase">
-                                {% trans 'Enterprise' %}
-                            </h3>
-                        </div>
-                    </div>
+                    {% include 'prelogin/_sections/pricing/partials/section_plan_headers.html' %}
                 </div>
             </div>
             <div class="container">

--- a/templates/prelogin/_sections/pricing/08_support.html
+++ b/templates/prelogin/_sections/pricing/08_support.html
@@ -18,33 +18,7 @@
                             </h2>
                         </div>
                     </div>
-                    <div class="row pricing-row pricing-row-plan-names">
-                        <div class="col-xs-2 pricing-col-community col-xs-offset-2">
-                            <h3 class="pricing-header text-uppercase">
-                                {% trans 'Community' %}
-                            </h3>
-                        </div>
-                        <div class="col-xs-2 pricing-col-standard">
-                            <h3 class="pricing-header text-uppercase">
-                                {% trans 'Standard' %}
-                            </h3>
-                        </div>
-                        <div class="col-xs-2 pricing-col-pro">
-                            <h3 class="pricing-header text-uppercase">
-                                {% trans 'Pro' %}
-                            </h3>
-                        </div>
-                        <div class="col-xs-2 pricing-col-advanced">
-                            <h3 class="pricing-header text-uppercase">
-                                {% trans 'Advanced' %}
-                            </h3>
-                        </div>
-                        <div class="col-xs-2 pricing-col-enterprise">
-                            <h3 class="pricing-header text-uppercase">
-                                {% trans 'Enterprise' %}
-                            </h3>
-                        </div>
-                    </div>
+                    {% include 'prelogin/_sections/pricing/partials/section_plan_headers.html' %}
                 </div>
             </div>
             <div class="container">

--- a/templates/prelogin/_sections/pricing/partials/pricing_checks.html
+++ b/templates/prelogin/_sections/pricing/partials/pricing_checks.html
@@ -1,0 +1,26 @@
+{% load pricing_tags %}
+<div class="col-xs-2 pricing-col-community">
+    <div class="pricing-info">
+        <p><i class="fa {% class_for_availability pricing_info.community %}"></i></p>
+    </div>
+</div>
+<div class="col-xs-2 pricing-col-standard">
+    <div class="pricing-info">
+        <p><i class="fa {% class_for_availability pricing_info.standard %}"></i></p>
+    </div>
+</div>
+<div class="col-xs-2 pricing-col-pro">
+    <div class="pricing-info">
+        <p><i class="fa {% class_for_availability pricing_info.pro %}"></i></p>
+    </div>
+</div>
+<div class="col-xs-2 pricing-col-advanced">
+    <div class="pricing-info">
+        <p><i class="fa {% class_for_availability pricing_info.advanced %}"></i></p>
+    </div>
+</div>
+<div class="col-xs-2 pricing-col-enterprise">
+    <div class="pricing-info">
+        <p><i class="fa {% class_for_availability pricing_info.enterprise %}"></i></p>
+    </div>
+</div>

--- a/templates/prelogin/_sections/pricing/partials/pricing_row_contents.html
+++ b/templates/prelogin/_sections/pricing/partials/pricing_row_contents.html
@@ -1,0 +1,4 @@
+<div class="col-xs-2">
+    <h4>{{ feature_name }}</h4>
+</div>
+{% include 'prelogin/_sections/pricing/partials/pricing_checks.html' %}

--- a/templates/prelogin/_sections/pricing/partials/section_plan_headers.html
+++ b/templates/prelogin/_sections/pricing/partials/section_plan_headers.html
@@ -1,0 +1,28 @@
+{% load i18n %}
+<div class="row pricing-row pricing-row-plan-names">
+    <div class="col-xs-2 pricing-col-community col-xs-offset-2">
+        <h3 class="pricing-header text-uppercase">
+            {% trans 'Community' %}
+        </h3>
+    </div>
+    <div class="col-xs-2 pricing-col-standard">
+        <h3 class="pricing-header text-uppercase">
+            {% trans 'Standard' %}
+        </h3>
+    </div>
+    <div class="col-xs-2 pricing-col-pro">
+        <h3 class="pricing-header text-uppercase">
+            {% trans 'Pro' %}
+        </h3>
+    </div>
+    <div class="col-xs-2 pricing-col-advanced">
+        <h3 class="pricing-header text-uppercase">
+            {% trans 'Advanced' %}
+        </h3>
+    </div>
+    <div class="col-xs-2 pricing-col-enterprise">
+        <h3 class="pricing-header text-uppercase">
+            {% trans 'Enterprise' %}
+        </h3>
+    </div>
+</div>

--- a/templatetags/pricing_tags.py
+++ b/templatetags/pricing_tags.py
@@ -1,0 +1,76 @@
+from django import template
+from django.template.loader import render_to_string
+
+register = template.Library()
+
+
+class PricingInfo(object):
+    """
+    Helper object for representing the availability of something on each plan.
+    """
+    COMMUNITY = 0
+    STANDARD = 1
+    PRO = 2
+    ADVANCED = 3
+    ENTERPRISE = 4
+
+    def __init__(self, level):
+        self.level = level
+
+    @staticmethod
+    def level_from_plan_name(plan_name):
+        lookup = {
+            'community': PricingInfo.COMMUNITY,
+            'standard': PricingInfo.STANDARD,
+            'pro': PricingInfo.PRO,
+            'advanced': PricingInfo.ADVANCED,
+            'enterprise': PricingInfo.ENTERPRISE,
+        }
+        if plan_name not in lookup:
+            raise ValueError('Plan name {} must be one of {}'.format(plan_name, ', '.join(lookup.keys())))
+        return lookup[plan_name]
+
+    @staticmethod
+    def from_plan_name(plan_name):
+        return PricingInfo(PricingInfo.level_from_plan_name(plan_name))
+
+    # these properties return whether the plan includes features at that level
+    @property
+    def community(self):
+        return self._check_level(self.COMMUNITY)
+
+    @property
+    def standard(self):
+        return self._check_level(self.STANDARD)
+
+    @property
+    def pro(self):
+        return self._check_level(self.PRO)
+
+    @property
+    def advanced(self):
+        return self._check_level(self.ADVANCED)
+
+    @property
+    def enterprise(self):
+        return self._check_level(self.ENTERPRISE)
+
+    def _check_level(self, level_to_check):
+        return self.level <= level_to_check
+
+
+@register.simple_tag
+def pricing_row_contents(feature_name, plan_name):
+    return render_to_string(
+        'prelogin/_sections/pricing/partials/pricing_row_contents.html',
+        {
+            'feature_name': feature_name,
+            'pricing_info': PricingInfo.from_plan_name(plan_name)
+        }
+    )
+
+
+@register.simple_tag
+def class_for_availability(is_available):
+    # used by the check marks tags
+    return 'fa-check' if is_available else 'fa-minus'


### PR DESCRIPTION
fixes http://manage.dimagi.com/default.asp?221541 as well as another small style thing I noticed on the pricing page in https://github.com/dimagi/commcarehq-prelogin/commit/fe384afbcbc00f8051b51b76376e6c1bfd642cb4

![image](https://cloud.githubusercontent.com/assets/66555/13914002/45b8ddc6-ef54-11e5-8404-86e263bfa027.png)

this was my first time poking my head into this page and couldn't bring myself to just copy/paste modify so did a bit of refactoring and DRYing up stuff. will make a backlog item to go port everything else over to this new way of doing things so I can get my :heavy_minus_sign: count up, even if it is the wrong repo...

@biyeun @orangejenny best reviewed commit by commit. main functional change is in https://github.com/dimagi/commcarehq-prelogin/commit/c6c73e73c082eb68aec24ec1d6689aad3b13d284