### PR TITLE
fixes gap in pricing table

### DIFF
--- a/static/prelogin/less/components/pricing-section.less
+++ b/static/prelogin/less/components/pricing-section.less
@@ -1,3 +1,22 @@
+/*
+PLEASE READ THIS BEFORE EDITING THE LESS BELOW!
+
+NOTE: When editing the sizes below AND the templates please be sure to test the
+layout in the following screen sizes of minimum width
+
+*-lg:  1200px
+*-md: 992px
+*-sm: 768px
+*-xs: 480px
+
+and update the heights below.
+
+Please also be aware of the row heights for each feature at each of these screen
+widths and adjust the classes for each row accordingly. The classes for the
+row heights can be found in components/pricing.less
+
+*/
+
 @pricing-first-section-height-xs: 257px;
 @pricing-first-section-height-sm: 257px;
 @pricing-first-section-height-md: 252px;

--- a/static/prelogin/less/components/pricing-section.less
+++ b/static/prelogin/less/components/pricing-section.less
@@ -13,9 +13,9 @@
 @pricing-third-section-height-md: 487px;
 @pricing-third-section-height-lg: 518px;
 
-@pricing-fourth-section-height-xs: 486px;
-@pricing-fourth-section-height-sm: 486px;
-@pricing-fourth-section-height-md: 481px;
+@pricing-fourth-section-height-xs: 440px;
+@pricing-fourth-section-height-sm: 440px;
+@pricing-fourth-section-height-md: 435px;
 @pricing-fourth-section-height-lg: 496px;
 
 @pricing-fifth-section-height-xs: 191px;

--- a/static/prelogin/less/components/pricing-section.less
+++ b/static/prelogin/less/components/pricing-section.less
@@ -37,9 +37,9 @@ row heights can be found in components/pricing.less
 @pricing-fourth-section-height-md: 435px;
 @pricing-fourth-section-height-lg: 496px;
 
-@pricing-fifth-section-height-xs: 191px;
-@pricing-fifth-section-height-sm: 176px;
-@pricing-fifth-section-height-md: 181px;
+@pricing-fifth-section-height-xs: 348px;
+@pricing-fifth-section-height-sm: 323px;
+@pricing-fifth-section-height-md: 318px;
 @pricing-fifth-section-height-lg: 363px;
 
 @pricing-sixth-section-height-xs: 354px;

--- a/templates/prelogin/_sections/pricing/05_data_security.html
+++ b/templates/prelogin/_sections/pricing/05_data_security.html
@@ -34,7 +34,7 @@
                     {% pricing_row_contents feature_name "pro" %}
                 </div>
                 <div class="row pricing-row pricing-row-main pricing-row-double
-                            pricing-row-triple-xs">
+                            pricing-row-triple-sm">
                     {% trans "Security Policy Control and Enforcement" as feature_name %}
                     {% pricing_row_contents feature_name "advanced" %}
                 </div>


### PR DESCRIPTION
@czue / @orangejenny 

cc @benrudolph 

Fixes this:
<img width="800" alt="screen shot 2016-03-28 at 4 17 51 pm" src="https://cloud.githubusercontent.com/assets/716573/14073063/d5624d34-f500-11e5-84cb-8a8fa9fab881.png">

also fixes the security section rows so that they're not hidden on smaller screen sizes---oops
