### PR TITLE
Fix hubspot and kissmetrics on prelogin site

### DIFF
--- a/templates/prelogin/base.html
+++ b/templates/prelogin/base.html
@@ -66,6 +66,8 @@
         {# Hubspot #}
         <script charset="utf-8" src="https://js.hscta.net/cta/current.js"></script>
         <script charset="utf-8" src="{% static 'prelogin/js/style_form.js' %}"></script>
+        {% include 'style/includes/analytics_kissmetrics.html' %}
+        {% include 'style/includes/analytics_hubspot.html' %}
 
         {% block js-inline %}
         {# needed for child pages #}
@@ -280,8 +282,5 @@
             ga('send', 'pageview');
         </script>
         {% endif %}
-
-        {% include 'style/includes/analytics_kissmetrics.html' %}
-        {% include 'style/includes/analytics_hubspot.html' %}
     </body>
 </html>


### PR DESCRIPTION
Looks like the advent of `{% addtoblock js-inline %}` in the included analytics snippets resulted in them never being rendered. The solution is to move them before the `js-inline` block. Fortunately Cal has a PR open that will prevent this from failing silently in the future:
https://github.com/dimagi/commcare-hq/pull/12966

@orangejenny @kaapstorm 