### PR TITLE
adding drift to base template

### DIFF
--- a/templates/prelogin/base.html
+++ b/templates/prelogin/base.html
@@ -68,6 +68,11 @@
         <script charset="utf-8" src="{% static 'prelogin/js/style_form.js' %}"></script>
         {% include 'style/includes/analytics_all.html' %}
 
+        {# drift and drift hubspot integration #}
+        <script src="{% static 'prelogin/js/drift.js' %}"></script>
+        <script src="{% static 'prelogin/js/hubspot_drift.js' %}"></script>
+
+
         {% if FULLSTORY_ID %}
         <script>
             window['_fs_debug'] = false;

--- a/templates/prelogin/home.html
+++ b/templates/prelogin/home.html
@@ -2,11 +2,6 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 
-{% block js-inline %}
-    <script src="{% static 'prelogin/js/drift.js' %}"></script>
-    <script src="{% static 'prelogin/js/hubspot_drift.js' %}"></script>
-{% endblock js-inline %}
-
 {% block stylesheets %}
 <link type="text/css"
       rel="stylesheet"

--- a/templates/prelogin/pricing.html
+++ b/templates/prelogin/pricing.html
@@ -2,11 +2,6 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 
-{% block js-inline %}
-    <script src="{% static 'prelogin/js/drift.js' %}"></script>
-    <script src="{% static 'prelogin/js/hubspot_drift.js' %}"></script>
-{% endblock js-inline %}
-
 {% block content %}
 {% include 'prelogin/_sections/pricing/lead.html' %}
 <div class="bg-static-fixed bg-pricing bg-pricing-first b-lazy" data-src="{% static 'prelogin/images/bg-pricing/bg-pricing-web-lg.jpg' %}"></div>

--- a/templates/prelogin/software_services.html
+++ b/templates/prelogin/software_services.html
@@ -2,11 +2,6 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 
-{% block js-inline %}
-    <script src="{% static 'prelogin/js/drift.js' %}"></script>
-    <script src="{% static 'prelogin/js/hubspot_drift.js' %}"></script>
-{% endblock js-inline %}
-
 {% block content %}
 {% include 'prelogin/_sections/software_services/lead.html' %}
 <div class="bg-static-fixed bg-position-bottom b-lazy" data-src="{% static 'prelogin/images/bg-software-services/bg-software-services-first-lg.jpg' %}"></div>


### PR DESCRIPTION
@czue 
This moves drift to all prelogin pages instead of just those 3. That way ryan can turn it on for whatever pages he chooses.