### PR TITLE
add Comms CTA for asking for a demo. 

### DIFF
--- a/static/prelogin/less/components/cta.less
+++ b/static/prelogin/less/components/cta.less
@@ -1,0 +1,42 @@
+.hubspot-form-cta .field label{
+  color: white;
+  font-size: 2.2rem;
+  .hs-form-required{
+    display: none;
+  }
+}
+
+.hubspot-form-cta .field input {
+  height: 58px;
+  padding: 0 20px;
+  font-size: 17px;
+  line-height: 1.6rem;
+  border-radius: 8px;
+  color: #555555;
+  background-color: #ffffff;
+  background-image: none;
+  border: 1px solid #cccccc;
+  margin: 10px 0;
+}
+
+.hubspot-form-cta {
+  .hs-form.stacked .actions {
+    margin-left: 0;
+  }
+}
+
+.hubspot-form-cta .hs-form.stacked .actions .hs-button {
+  color: #ffffff;
+  background-color: #47b700;
+  border: 1px solid #3d9e00;
+  padding: 14px 20px;
+  font-size: 17px;
+  line-height: 1.6;
+  border-radius: 8px;
+  background-image: none;
+  box-shadow: none;
+}
+
+.hubspot-form-cta h1 {
+  margin-bottom: 10px;
+}

--- a/static/prelogin/less/components/navbar.less
+++ b/static/prelogin/less/components/navbar.less
@@ -3,7 +3,7 @@
 }
 
 .navbar-default .navbar-brand {
-  padding: 5px @navbar-padding-horizontal;
+  padding: 9px @navbar-padding-horizontal;
 }
 
 .navbar-static-hq {

--- a/static/prelogin/less/public-style-imports.less
+++ b/static/prelogin/less/public-style-imports.less
@@ -22,3 +22,4 @@
 @import "components/home";
 @import "components/solutions";
 @import "components/next";
+@import "components/cta";

--- a/templates/prelogin/base.html
+++ b/templates/prelogin/base.html
@@ -173,11 +173,12 @@
                         <li{% if is_solutions %} class="active"{% endif %}><a href="{% prelogin_url 'public_solutions' %}">{% trans "Solutions" %}</a></li>
                         <li{% if is_impact %} class="active"{% endif %}><a href="{% prelogin_url 'public_impact' %}">{% trans "Impact" %}</a></li>
                         <li{% if is_software_services %} class="active"{% endif %}><a href="{% prelogin_url 'public_software_services' %}">{% trans "Pricing" %}</a></li>
-                        {% if show_demo %}
-                            <li class="{% if is_demo %}active {% endif %}demo"><a href="{% prelogin_url 'public_demo' %}">Demo</a></li>
-                        {% endif %}
                     </ul>
                     <div class="navbar-right">
+                        <a href="{% prelogin_url 'public_demo_cta' %}"
+                           class="btn btn-purple navbar-btn">
+                          {% trans "Ask for a Demo" %}
+                        </a>
                         <a href="{% url 'login' %}"
                            class="btn btn-primary navbar-btn">
                             {% trans 'Sign In' %}

--- a/templates/prelogin/demo_cta.html
+++ b/templates/prelogin/demo_cta.html
@@ -1,0 +1,39 @@
+{% extends 'prelogin/base.html' %}
+{% load i18n %}
+{% load hq_shared_tags %}
+
+{% block content %}
+<section class="section section-primary section-lead section-fullheader" style="height: 350px;">
+    <div class="container">
+        <div class="row">
+            <div class="hubspot-form-cta">
+
+              <h1>
+                {% blocktrans %}Schedule a Demo with us today!{% endblocktrans %}
+              </h1>
+              <p class="lead">
+                {% blocktrans %}
+                CommCare is a very powerful, flexible tool. We'd love to give you some
+                  inspiration for how you can put it to use.
+                {% endblocktrans %}
+              </p>
+
+              <!--[if lte IE 8]>
+              <script charset="utf-8" type="text/javascript" src="//js.hsforms.net/forms/v2-legacy.js"></script>
+              <![endif]-->
+              <script charset="utf-8" type="text/javascript" src="//js.hsforms.net/forms/v2.js"></script>
+              <script>
+                hbspt.forms.create({
+                  css: '',
+                  portalId: '503070',
+                  formId: '93ea1a30-ca79-444f-ad19-f0e8187b17c0'
+                });
+              </script>
+
+            </div>
+        </div>
+    </div>
+</section>
+<div class="bg-static-fixed bg-position-bottom b-lazy" data-src="{% static 'prelogin/images/bg-solutions/bg-solutions-second-lg.jpg' %}"></div>
+
+{% endblock content %}

--- a/urls.py
+++ b/urls.py
@@ -18,6 +18,8 @@ root_patterns = [
         name=PricingPublicView.urlname),
     url(r'^solutions/$', SolutionsPublicView.as_view(),
         name=SolutionsPublicView.urlname),
+    url(r'^askdemo/$', DemoFormCTA.as_view(),
+        name=DemoFormCTA.urlname),
     url(r'^supply/$', RedirectView.as_view(url='/solutions/#supply', permanent=True)),
 ]
 

--- a/views.py
+++ b/views.py
@@ -125,6 +125,15 @@ class HomePublicView(BasePreloginView):
         return super(HomePublicView, self).get_context_data(**kwargs)
 
 
+class DemoFormCTA(BasePreloginView):
+    urlname = 'public_demo_cta'
+    template_name = 'prelogin/demo_cta.html'
+
+    def get_context_data(self, **kwargs):
+        kwargs['is_demo_cta'] = True
+        return super(DemoFormCTA, self).get_context_data(**kwargs)
+
+
 class ImpactPublicView(BasePreloginView):
     urlname = 'public_impact'
     template_name = 'prelogin/impact.html'


### PR DESCRIPTION
@orangejenny 

cc @esoergel / @calellowitz 

This addresses the Comms team CTA to add an ask for a demo button that links to a hubspot form.

@orangejenny what's the status of the demo that was there? I removed it from navigation to reduce confusion for this CTA campaign which has to go out ASAP.

<img width="1288" alt="screen shot 2017-02-24 at 4 53 17 pm" src="https://cloud.githubusercontent.com/assets/716573/23322535/67fa54e0-fab2-11e6-9f53-12327a8f68e4.png">
