### PR TITLE
adding back js-inline block

### DIFF
--- a/templates/prelogin/base.html
+++ b/templates/prelogin/base.html
@@ -129,6 +129,9 @@
             <script src="{% static 'less/dist/less-1.7.3.min.js' %}"></script>
             {% if less_watch %}<script>less.watch();</script>{% endif %}
         {% endif %}
+        {% block js-inline %}
+            {# needed for analytics #}
+        {% endblock js-inline %}
     </head>
     <body>
         <nav class="navbar navbar-default navbar-static-hq navbar-fixed-top" role="navigation">


### PR DESCRIPTION
@orangejenny cc: @nickpell  
This was removed in https://github.com/dimagi/commcarehq-prelogin/pull/117 and accidentally got rid of much of our analytics which are added to the js-inline block