### PR TITLE
add zapier to software plans page

### DIFF
--- a/static/prelogin/less/components/pricing-section.less
+++ b/static/prelogin/less/components/pricing-section.less
@@ -111,16 +111,16 @@ row heights can be found in components/pricing-row.less
 //// SEVENTH SECTION ////
 
 // English
-@seventh-xs-en: 356px;
-@seventh-sm-en: 336px;
-@seventh-md-en: 317px;
-@seventh-lg-en: 365px;
+@seventh-xs-en: 390px;
+@seventh-sm-en: 375px;
+@seventh-md-en: 370px;
+@seventh-lg-en: 420px;
 
 // French
-@seventh-xs-fra: 399px;
-@seventh-sm-fra: 374px;
-@seventh-md-fra: 348px;
-@seventh-lg-fra: 397px;
+@seventh-xs-fra: 433px;
+@seventh-sm-fra: 415px;
+@seventh-md-fra: 401px;
+@seventh-lg-fra: 452px;
 
 
 //// EIGHTH SECTION ////

--- a/templates/prelogin/_sections/pricing/07_system_integration.html
+++ b/templates/prelogin/_sections/pricing/07_system_integration.html
@@ -31,6 +31,11 @@
                 </div>
                 <div class="row pricing-row pricing-row-main
                             pricing-row-1x-lg">
+                    {% trans "Zapier Integration" as feature_name %}
+                    {% pricing_row_contents feature_name "standard" %}
+                </div>
+                <div class="row pricing-row pricing-row-main
+                            pricing-row-1x-lg">
                     {% trans "API access" as feature_name %}
                     {% pricing_row_contents feature_name "standard" %}
                 </div>


### PR DESCRIPTION
this adds zapier integration (now in public beta) to the pricing page. cc @dimagi/product in case you have any feedback on the wording.

![image](https://user-images.githubusercontent.com/66555/29185302-ccf02c60-7dd6-11e7-90e4-be845324a173.png)

this was not as easy as I expected it to be! these manual heights are rough. 

I tested all the browser sizes locally in English and then just extrapolated for french because changing the language wasn't working. might be worth a second pair of eyes double checking this - especially the french version - before it gets merged ( @biyeun looks like you were just in here?). also my fonts seemed slightly different locally from prod (not sure why)...