### PR TITLE
Some prelogin optimizations

### DIFF
--- a/views.py
+++ b/views.py
@@ -146,7 +146,7 @@ class ImpactPublicView(BasePreloginView):
 class SoftwareServicesPublicView(BasePreloginView):
     urlname = 'public_software_services'
     template_name = u'prelogin/software_services.html'
-    slug = 'software_services'
+    slug = 'pricing'
 
     def get_context_data(self, **kwargs):
         kwargs['is_software_services'] = True
@@ -156,7 +156,7 @@ class SoftwareServicesPublicView(BasePreloginView):
 class PricingPublicView(BasePreloginView):
     urlname = 'public_pricing'
     template_name = u'prelogin/pricing.html'
-    slug = 'pricing'
+    slug = 'software'
 
     def get_context_data(self, **kwargs):
         kwargs['is_software_services'] = True

--- a/views.py
+++ b/views.py
@@ -42,6 +42,8 @@ class BasePreloginView(TemplateView):
     hubspot_portal_id = HUBSPOT_PORTAL_IDS[MAIN_FORM]
     hubspot_form_id = HUBSPOT_FORM_IDS[MAIN_FORM]
 
+    slug = '' # doing this because the reverse() lookup takes waaaay too long on initial load
+
     def get_context_data(self, **kwargs):
         kwargs['hubspot'] = {
             'portal_id': self.hubspot_portal_id,
@@ -85,9 +87,12 @@ class BasePreloginView(TemplateView):
             with translation.override(lang_code):
                 localized_options.append({
                     'display_label': _(display_label),
-                    'prefix_url': reverse(self.urlname, args=[lang_code])
-                })
 
+                    # we do this instead of reverse because the first call to
+                    # reverse takes an _absurdly_ long time for this to be the first
+                    # thing that people hit when visiting www.comcmarehq.org.
+                    'prefix_url': '/lang/{}/{}/'.format(lang_code, self.slug),
+                })
         return {
             'language_options': localized_options,
             'current_lang_name': _(aliased_language_name(translation.get_language())),
@@ -98,6 +103,7 @@ class BasePreloginView(TemplateView):
 class HomePublicView(BasePreloginView):
     urlname = 'public_home'
     template_name = 'prelogin/home.html'
+    slug = 'home'
 
     def get_context_data(self, **kwargs):
         kwargs['is_home'] = True
@@ -107,6 +113,7 @@ class HomePublicView(BasePreloginView):
 class DemoFormCTA(BasePreloginView):
     urlname = 'public_demo_cta'
     template_name = 'prelogin/demo_cta.html'
+    slug = 'askdemo'
 
     def get_context_data(self, **kwargs):
         kwargs['is_demo_cta'] = True
@@ -116,6 +123,7 @@ class DemoFormCTA(BasePreloginView):
 class ImpactPublicView(BasePreloginView):
     urlname = 'public_impact'
     template_name = 'prelogin/impact.html'
+    slug = 'impact'
 
     def get_context_data(self, **kwargs):
         pub_col1 = os.path.join(
@@ -138,6 +146,7 @@ class ImpactPublicView(BasePreloginView):
 class SoftwareServicesPublicView(BasePreloginView):
     urlname = 'public_software_services'
     template_name = 'prelogin/software_services.html'
+    slug = 'software_services'
 
     def get_context_data(self, **kwargs):
         kwargs['is_software_services'] = True
@@ -147,6 +156,7 @@ class SoftwareServicesPublicView(BasePreloginView):
 class PricingPublicView(BasePreloginView):
     urlname = 'public_pricing'
     template_name = 'prelogin/pricing.html'
+    slug = 'pricing'
 
     def get_context_data(self, **kwargs):
         kwargs['is_software_services'] = True
@@ -156,6 +166,7 @@ class PricingPublicView(BasePreloginView):
 class ServicesPublicView(BasePreloginView):
     urlname = 'public_services'
     template_name = 'prelogin/services.html'
+    slug = 'services'
 
     def get_context_data(self, **kwargs):
         kwargs['is_software_services'] = True
@@ -167,6 +178,7 @@ class SolutionsPublicView(BasePreloginView):
     template_name = 'prelogin/solutions.html'
     hubspot_portal_id = HUBSPOT_PORTAL_IDS[SUPPLY_FORM]
     hubspot_form_id = HUBSPOT_FORM_IDS[SUPPLY_FORM]
+    slug = 'solutions'
 
     def get_context_data(self, **kwargs):
         kwargs['is_solutions'] = True

--- a/views.py
+++ b/views.py
@@ -102,7 +102,7 @@ class BasePreloginView(TemplateView):
 
 class HomePublicView(BasePreloginView):
     urlname = 'public_home'
-    template_name = 'prelogin/home.html'
+    template_name = u'prelogin/home.html'
     slug = 'home'
 
     def get_context_data(self, **kwargs):
@@ -112,7 +112,7 @@ class HomePublicView(BasePreloginView):
 
 class DemoFormCTA(BasePreloginView):
     urlname = 'public_demo_cta'
-    template_name = 'prelogin/demo_cta.html'
+    template_name = u'prelogin/demo_cta.html'
     slug = 'askdemo'
 
     def get_context_data(self, **kwargs):
@@ -122,7 +122,7 @@ class DemoFormCTA(BasePreloginView):
 
 class ImpactPublicView(BasePreloginView):
     urlname = 'public_impact'
-    template_name = 'prelogin/impact.html'
+    template_name = u'prelogin/impact.html'
     slug = 'impact'
 
     def get_context_data(self, **kwargs):
@@ -145,7 +145,7 @@ class ImpactPublicView(BasePreloginView):
 
 class SoftwareServicesPublicView(BasePreloginView):
     urlname = 'public_software_services'
-    template_name = 'prelogin/software_services.html'
+    template_name = u'prelogin/software_services.html'
     slug = 'software_services'
 
     def get_context_data(self, **kwargs):
@@ -155,7 +155,7 @@ class SoftwareServicesPublicView(BasePreloginView):
 
 class PricingPublicView(BasePreloginView):
     urlname = 'public_pricing'
-    template_name = 'prelogin/pricing.html'
+    template_name = u'prelogin/pricing.html'
     slug = 'pricing'
 
     def get_context_data(self, **kwargs):
@@ -165,7 +165,7 @@ class PricingPublicView(BasePreloginView):
 
 class ServicesPublicView(BasePreloginView):
     urlname = 'public_services'
-    template_name = 'prelogin/services.html'
+    template_name = u'prelogin/services.html'
     slug = 'services'
 
     def get_context_data(self, **kwargs):
@@ -175,7 +175,7 @@ class ServicesPublicView(BasePreloginView):
 
 class SolutionsPublicView(BasePreloginView):
     urlname = 'public_solutions'
-    template_name = 'prelogin/solutions.html'
+    template_name = u'prelogin/solutions.html'
     hubspot_portal_id = HUBSPOT_PORTAL_IDS[SUPPLY_FORM]
     hubspot_form_id = HUBSPOT_FORM_IDS[SUPPLY_FORM]
     slug = 'solutions'


### PR DESCRIPTION
Upon profiling the prelogin views, I discovered that calling `reverse` on any of the view names results in calling `regex_helper` a grand total of `153090` times. 😱  Resulting in `11.243ms` of unnecessary processing. The thought that this might be only the initial few runs of `reverse` but we still shouldn't have this be the first thing that's hit by users if we want to optimize this page.

In addition to this I will get nginx to cache these prelogin pages a little harder.
Ehhh....

@dannyroberts 
cc @kaapstorm 

